### PR TITLE
feat: Implement authentication UI flow with protected routes

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "shadcn": {
+      "command": "npx",
+      "args": ["shadcn@latest", "mcp"]
+    }
+  }
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,8 +4,12 @@ import { OrganizationList } from "@/pages/OrganizationList"
 import { OrganizationDetail } from "@/pages/OrganizationDetail"
 import { GatewayList } from "@/pages/GatewayList"
 import { DeviceList } from "@/pages/DeviceList"
+import { LoginPage } from "@/pages/LoginPage"
+import { SignupPage } from "@/pages/SignupPage"
 import { AppSidebar } from "@/components/layout"
+import { RequireAuth } from "@/components/auth"
 import { ThemeProvider } from "@/components/theme-provider"
+import { AuthProvider } from "@/lib/auth"
 import { organizationClient } from "@/lib/api"
 
 function MainLayout() {
@@ -43,19 +47,39 @@ function OrganizationLayout() {
 function App() {
   return (
     <ThemeProvider defaultTheme="system">
-      <BrowserRouter>
-        <Routes>
-          <Route element={<MainLayout />}>
-            <Route path="/" element={<OrganizationList />} />
-            <Route path="/organizations" element={<OrganizationList />} />
-          </Route>
-          <Route path="/organizations/:orgId" element={<OrganizationLayout />}>
-            <Route index element={<OrganizationDetail />} />
-            <Route path="gateways" element={<GatewayList />} />
-            <Route path="devices" element={<DeviceList />} />
-          </Route>
-        </Routes>
-      </BrowserRouter>
+      <AuthProvider>
+        <BrowserRouter>
+          <Routes>
+            {/* Public routes */}
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/signup" element={<SignupPage />} />
+
+            {/* Protected routes */}
+            <Route
+              element={
+                <RequireAuth>
+                  <MainLayout />
+                </RequireAuth>
+              }
+            >
+              <Route path="/" element={<OrganizationList />} />
+              <Route path="/organizations" element={<OrganizationList />} />
+            </Route>
+            <Route
+              path="/organizations/:orgId"
+              element={
+                <RequireAuth>
+                  <OrganizationLayout />
+                </RequireAuth>
+              }
+            >
+              <Route index element={<OrganizationDetail />} />
+              <Route path="gateways" element={<GatewayList />} />
+              <Route path="devices" element={<DeviceList />} />
+            </Route>
+          </Routes>
+        </BrowserRouter>
+      </AuthProvider>
     </ThemeProvider>
   )
 }

--- a/apps/web/src/components/auth/RequireAuth.tsx
+++ b/apps/web/src/components/auth/RequireAuth.tsx
@@ -1,0 +1,27 @@
+import { Navigate, useLocation } from "react-router-dom"
+import { useAuth } from "@/lib/auth"
+
+interface RequireAuthProps {
+  children: React.ReactNode
+}
+
+export function RequireAuth({ children }: RequireAuthProps) {
+  const { isAuthenticated, isLoading } = useAuth()
+  const location = useLocation()
+
+  if (isLoading) {
+    // Show loading state while checking auth
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="text-muted-foreground">Loading...</div>
+      </div>
+    )
+  }
+
+  if (!isAuthenticated) {
+    // Redirect to login, preserving the intended destination
+    return <Navigate to="/login" state={{ from: location.pathname }} replace />
+  }
+
+  return <>{children}</>
+}

--- a/apps/web/src/components/auth/index.ts
+++ b/apps/web/src/components/auth/index.ts
@@ -1,0 +1,1 @@
+export { RequireAuth } from "./RequireAuth"

--- a/apps/web/src/components/layout/AppSidebar.tsx
+++ b/apps/web/src/components/layout/AppSidebar.tsx
@@ -3,6 +3,7 @@ import { Building2, Radio, Cpu, Home, Moon, Sun } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { useTheme } from "@/components/theme-provider"
+import { UserMenu } from "./UserMenu"
 
 interface NavItemProps {
   to: string
@@ -113,6 +114,11 @@ export function AppSidebar({ organizationId, organizationName }: AppSidebarProps
             </nav>
           </>
         )}
+      </div>
+
+      {/* User Menu */}
+      <div className="border-t p-2">
+        <UserMenu />
       </div>
     </div>
   )

--- a/apps/web/src/components/layout/UserMenu.tsx
+++ b/apps/web/src/components/layout/UserMenu.tsx
@@ -1,0 +1,63 @@
+import { LogOut, User } from "lucide-react"
+import { useAuth } from "@/lib/auth"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+export function UserMenu() {
+  const { user, logout } = useAuth()
+
+  if (!user) return null
+
+  // Get initials from name
+  const initials = user.name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2)
+
+  const handleLogout = async () => {
+    await logout()
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="w-full justify-start gap-2 px-2">
+          <Avatar className="h-8 w-8">
+            <AvatarFallback className="bg-primary/10 text-primary text-xs">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+          <div className="flex flex-1 flex-col items-start text-sm">
+            <span className="font-medium">{user.name}</span>
+            <span className="text-xs text-muted-foreground truncate max-w-[140px]">
+              {user.email}
+            </span>
+          </div>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-56">
+        <DropdownMenuLabel>My Account</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem disabled>
+          <User className="mr-2 h-4 w-4" />
+          Profile (coming soon)
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={handleLogout} className="text-destructive">
+          <LogOut className="mr-2 h-4 w-4" />
+          Log out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/web/src/components/layout/index.ts
+++ b/apps/web/src/components/layout/index.ts
@@ -1,2 +1,3 @@
 export { AppLayout } from "./AppLayout"
 export { AppSidebar } from "./AppSidebar"
+export { UserMenu } from "./UserMenu"

--- a/apps/web/src/components/ui/field.tsx
+++ b/apps/web/src/components/ui/field.tsx
@@ -1,0 +1,246 @@
+import { useMemo } from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+
+function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
+  return (
+    <fieldset
+      data-slot="field-set"
+      className={cn(
+        "flex flex-col gap-6",
+        "has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldLegend({
+  className,
+  variant = "legend",
+  ...props
+}: React.ComponentProps<"legend"> & { variant?: "legend" | "label" }) {
+  return (
+    <legend
+      data-slot="field-legend"
+      data-variant={variant}
+      className={cn(
+        "mb-3 font-medium",
+        "data-[variant=legend]:text-base",
+        "data-[variant=label]:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-group"
+      className={cn(
+        "group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&>[data-slot=field-group]]:gap-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const fieldVariants = cva(
+  "group/field flex w-full gap-3 data-[invalid=true]:text-destructive",
+  {
+    variants: {
+      orientation: {
+        vertical: ["flex-col [&>*]:w-full [&>.sr-only]:w-auto"],
+        horizontal: [
+          "flex-row items-center",
+          "[&>[data-slot=field-label]]:flex-auto",
+          "has-[>[data-slot=field-content]]:items-start has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+        ],
+        responsive: [
+          "flex-col [&>*]:w-full [&>.sr-only]:w-auto @md/field-group:flex-row @md/field-group:items-center @md/field-group:[&>*]:w-auto",
+          "@md/field-group:[&>[data-slot=field-label]]:flex-auto",
+          "@md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+        ],
+      },
+    },
+    defaultVariants: {
+      orientation: "vertical",
+    },
+  }
+)
+
+function Field({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="field"
+      data-orientation={orientation}
+      className={cn(fieldVariants({ orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-content"
+      className={cn(
+        "group/field-content flex flex-1 flex-col gap-1.5 leading-snug",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof Label>) {
+  return (
+    <Label
+      data-slot="field-label"
+      className={cn(
+        "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50",
+        "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4",
+        "has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-label"
+      className={cn(
+        "flex w-fit items-center gap-2 text-sm leading-snug font-medium group-data-[disabled=true]/field:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="field-description"
+      className={cn(
+        "text-muted-foreground text-sm leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance",
+        "last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5",
+        "[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  children?: React.ReactNode
+}) {
+  return (
+    <div
+      data-slot="field-separator"
+      data-content={!!children}
+      className={cn(
+        "relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2",
+        className
+      )}
+      {...props}
+    >
+      <Separator className="absolute inset-0 top-1/2" />
+      {children && (
+        <span
+          className="bg-background text-muted-foreground relative mx-auto block w-fit px-2"
+          data-slot="field-separator-content"
+        >
+          {children}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function FieldError({
+  className,
+  children,
+  errors,
+  ...props
+}: React.ComponentProps<"div"> & {
+  errors?: Array<{ message?: string } | undefined>
+}) {
+  const content = useMemo(() => {
+    if (children) {
+      return children
+    }
+
+    if (!errors?.length) {
+      return null
+    }
+
+    const uniqueErrors = [
+      ...new Map(errors.map((error) => [error?.message, error])).values(),
+    ]
+
+    if (uniqueErrors?.length == 1) {
+      return uniqueErrors[0]?.message
+    }
+
+    return (
+      <ul className="ml-4 flex list-disc flex-col gap-1">
+        {uniqueErrors.map(
+          (error, index) =>
+            error?.message && <li key={index}>{error.message}</li>
+        )}
+      </ul>
+    )
+  }, [children, errors])
+
+  if (!content) {
+    return null
+  }
+
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={cn("text-destructive text-sm font-normal", className)}
+      {...props}
+    >
+      {content}
+    </div>
+  )
+}
+
+export {
+  Field,
+  FieldLabel,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldContent,
+  FieldTitle,
+}

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -4,10 +4,12 @@ import { transport } from "./transport"
 import { OrganizationService } from "@buf/ponix_ponix.bufbuild_es/organization/v1/organization_pb"
 import { GatewayService } from "@buf/ponix_ponix.bufbuild_es/gateway/v1/gateway_pb"
 import { EndDeviceService } from "@buf/ponix_ponix.bufbuild_es/end_device/v1/end_device_pb"
+import { UserService } from "@buf/ponix_ponix.bufbuild_es/user/v1/user_pb"
 
 export const organizationClient = createClient(OrganizationService, transport)
 export const gatewayClient = createClient(GatewayService, transport)
 export const endDeviceClient = createClient(EndDeviceService, transport)
+export const userClient = createClient(UserService, transport)
 
 // Re-export types for convenience
 export type {
@@ -51,3 +53,17 @@ export type {
   ListEndDevicesRequest,
   ListEndDevicesResponse,
 } from "@buf/ponix_ponix.bufbuild_es/end_device/v1/end_device_pb"
+
+export type {
+  User,
+  RegisterUserRequest,
+  RegisterUserResponse,
+  LoginRequest,
+  LoginResponse,
+  RefreshRequest,
+  RefreshResponse,
+  LogoutRequest,
+  LogoutResponse,
+  GetUserRequest,
+  GetUserResponse,
+} from "@buf/ponix_ponix.bufbuild_es/user/v1/user_pb"

--- a/apps/web/src/lib/api/index.ts
+++ b/apps/web/src/lib/api/index.ts
@@ -2,9 +2,10 @@ export {
   organizationClient,
   gatewayClient,
   endDeviceClient,
+  userClient,
 } from "./client"
 
-export { transport } from "./transport"
+export { transport, setTokenGetter } from "./transport"
 
 // Re-export all types
 export type {
@@ -34,6 +35,17 @@ export type {
   GetEndDeviceResponse,
   ListEndDevicesRequest,
   ListEndDevicesResponse,
+  User,
+  RegisterUserRequest,
+  RegisterUserResponse,
+  LoginRequest,
+  LoginResponse,
+  RefreshRequest,
+  RefreshResponse,
+  LogoutRequest,
+  LogoutResponse,
+  GetUserRequest,
+  GetUserResponse,
 } from "./client"
 
 export {

--- a/apps/web/src/lib/api/transport.ts
+++ b/apps/web/src/lib/api/transport.ts
@@ -2,6 +2,29 @@ import { createGrpcWebTransport } from "@connectrpc/connect-web"
 
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:50051"
 
+// Token getter - will be set by AuthContext
+let getAccessToken: (() => string | null) | null = null
+
+export function setTokenGetter(getter: () => string | null) {
+  getAccessToken = getter
+}
+
 export const transport = createGrpcWebTransport({
   baseUrl: API_URL,
+  // Custom fetch to include credentials and auth header
+  fetch: (input, init) => {
+    const headers = new Headers(init?.headers)
+
+    // Add Bearer token if available
+    const token = getAccessToken?.()
+    if (token) {
+      headers.set("Authorization", `Bearer ${token}`)
+    }
+
+    return fetch(input, {
+      ...init,
+      headers,
+      credentials: "include", // For HTTP-only refresh token cookie
+    })
+  },
 })

--- a/apps/web/src/lib/auth/AuthContext.tsx
+++ b/apps/web/src/lib/auth/AuthContext.tsx
@@ -1,0 +1,150 @@
+import { createContext, useContext, useState, useEffect, useCallback, useRef, type ReactNode } from "react"
+import { userClient, setTokenGetter } from "@/lib/api"
+import type { AuthContextValue, AuthUser } from "./types"
+
+const AuthContext = createContext<AuthContextValue | null>(null)
+
+// JWT decode helper (no validation, just extract payload)
+function decodeJwtPayload(token: string): { sub: string; email: string; exp: number } | null {
+  try {
+    const payload = token.split(".")[1]
+    return JSON.parse(atob(payload))
+  } catch {
+    return null
+  }
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null)
+  const [accessToken, setAccessToken] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  // Use ref to avoid stale closure in token getter
+  const accessTokenRef = useRef<string | null>(null)
+  accessTokenRef.current = accessToken
+
+  // Register token getter with transport on mount
+  useEffect(() => {
+    setTokenGetter(() => accessTokenRef.current)
+  }, [])
+
+  const isAuthenticated = !!user && !!accessToken
+
+  // Refresh auth token (called on mount and before expiration)
+  const refreshAuth = useCallback(async (): Promise<boolean> => {
+    try {
+      const response = await userClient.refresh({})
+      const token = response.accessToken
+      setAccessToken(token)
+
+      // Extract user info from token
+      const payload = decodeJwtPayload(token)
+      if (payload) {
+        // Fetch full user details
+        const userResponse = await userClient.getUser({ userId: payload.sub })
+        if (userResponse.user) {
+          setUser({
+            id: userResponse.user.id,
+            email: userResponse.user.email,
+            name: userResponse.user.name,
+          })
+        }
+      }
+      return true
+    } catch {
+      setUser(null)
+      setAccessToken(null)
+      return false
+    }
+  }, [])
+
+  // Login
+  const login = useCallback(async (email: string, password: string) => {
+    const response = await userClient.login({ email, password })
+    const token = response.token
+    setAccessToken(token)
+
+    // Extract user info from token and fetch user details
+    const payload = decodeJwtPayload(token)
+    if (payload) {
+      const userResponse = await userClient.getUser({ userId: payload.sub })
+      if (userResponse.user) {
+        setUser({
+          id: userResponse.user.id,
+          email: userResponse.user.email,
+          name: userResponse.user.name,
+        })
+      }
+    }
+  }, [])
+
+  // Register
+  const register = useCallback(async (email: string, password: string, name: string) => {
+    await userClient.registerUser({ email, password, name })
+    // After registration, log the user in
+    await login(email, password)
+  }, [login])
+
+  // Logout
+  const logout = useCallback(async () => {
+    try {
+      await userClient.logout({})
+    } finally {
+      setUser(null)
+      setAccessToken(null)
+    }
+  }, [])
+
+  // Try to refresh on mount (checks for existing session via refresh cookie)
+  useEffect(() => {
+    refreshAuth().finally(() => setIsLoading(false))
+  }, [refreshAuth])
+
+  // Set up token refresh before expiration
+  useEffect(() => {
+    if (!accessToken) return
+
+    const payload = decodeJwtPayload(accessToken)
+    if (!payload) return
+
+    // Refresh 1 minute before expiration
+    const expiresAt = payload.exp * 1000
+    const refreshAt = expiresAt - 60_000
+    const delay = refreshAt - Date.now()
+
+    if (delay <= 0) {
+      refreshAuth()
+      return
+    }
+
+    const timer = setTimeout(() => {
+      refreshAuth()
+    }, delay)
+
+    return () => clearTimeout(timer)
+  }, [accessToken, refreshAuth])
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        isAuthenticated,
+        isLoading,
+        login,
+        register,
+        logout,
+        refreshAuth,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider")
+  }
+  return context
+}

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -1,0 +1,2 @@
+export { AuthProvider, useAuth } from "./AuthContext"
+export type { AuthUser, AuthState, AuthContextValue } from "./types"

--- a/apps/web/src/lib/auth/types.ts
+++ b/apps/web/src/lib/auth/types.ts
@@ -1,0 +1,18 @@
+export interface AuthUser {
+  id: string
+  email: string
+  name: string
+}
+
+export interface AuthState {
+  user: AuthUser | null
+  isAuthenticated: boolean
+  isLoading: boolean
+}
+
+export interface AuthContextValue extends AuthState {
+  login: (email: string, password: string) => Promise<void>
+  register: (email: string, password: string, name: string) => Promise<void>
+  logout: () => Promise<void>
+  refreshAuth: () => Promise<boolean>
+}

--- a/apps/web/src/pages/DeviceList.tsx
+++ b/apps/web/src/pages/DeviceList.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import { useParams } from "react-router-dom"
-import { timestampDate } from "@bufbuild/protobuf/wkt"
+import { timestampDate, type Timestamp } from "@bufbuild/protobuf/wkt"
 import { Cpu, Plus } from "lucide-react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -73,7 +73,7 @@ export function DeviceList() {
     }
   }
 
-  const formatDate = (timestamp: { seconds: bigint; nanos: number } | undefined) => {
+  const formatDate = (timestamp: Timestamp | undefined) => {
     if (!timestamp) return "—"
     return timestampDate(timestamp).toLocaleString()
   }

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,0 +1,126 @@
+import { useState } from "react"
+import { useNavigate, useLocation, Link } from "react-router-dom"
+import { Radio } from "lucide-react"
+import { useAuth } from "@/lib/auth"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Field,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
+
+function LoginForm({ className, ...props }: React.ComponentProps<"div">) {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { login } = useAuth()
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const from = (location.state as { from?: string })?.from || "/organizations"
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setError(null)
+    setIsLoading(true)
+
+    const formData = new FormData(e.currentTarget)
+    const email = formData.get("email") as string
+    const password = formData.get("password") as string
+
+    try {
+      await login(email, password)
+      navigate(from, { replace: true })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Login failed"
+      // Format gRPC error codes into user-friendly messages
+      if (message.includes("[unauthenticated]")) {
+        setError("Invalid email or password.")
+      } else {
+        setError(message)
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-6", className)} {...props}>
+      <Card>
+        <CardHeader className="text-center">
+          <CardTitle className="text-xl">Welcome back</CardTitle>
+          <CardDescription>Sign in to your Ponix account</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit}>
+            <FieldGroup>
+              {error && (
+                <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                  {error}
+                </div>
+              )}
+              <Field>
+                <FieldLabel htmlFor="email">Email</FieldLabel>
+                <Input
+                  id="email"
+                  name="email"
+                  type="email"
+                  placeholder="m@example.com"
+                  required
+                  disabled={isLoading}
+                />
+              </Field>
+              <Field>
+                <FieldLabel htmlFor="password">Password</FieldLabel>
+                <Input
+                  id="password"
+                  name="password"
+                  type="password"
+                  required
+                  disabled={isLoading}
+                />
+              </Field>
+              <Field>
+                <Button type="submit" disabled={isLoading}>
+                  {isLoading ? "Signing in..." : "Sign in"}
+                </Button>
+                <FieldDescription className="text-center">
+                  Don&apos;t have an account?{" "}
+                  <Link to="/signup" state={{ from }}>
+                    Sign up
+                  </Link>
+                </FieldDescription>
+              </Field>
+            </FieldGroup>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export function LoginPage() {
+  return (
+    <div className="bg-muted flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
+      <div className="flex w-full max-w-sm flex-col gap-6">
+        <a href="/" className="flex items-center gap-2 self-center font-medium">
+          <div className="bg-primary text-primary-foreground flex size-6 items-center justify-center rounded-md">
+            <Radio className="size-4" />
+          </div>
+          Ponix
+        </a>
+        <LoginForm />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/OrganizationDetail.tsx
+++ b/apps/web/src/pages/OrganizationDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import { useParams } from "react-router-dom"
-import { timestampDate } from "@bufbuild/protobuf/wkt"
+import { timestampDate, type Timestamp } from "@bufbuild/protobuf/wkt"
 import { Radio, Cpu } from "lucide-react"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -112,7 +112,7 @@ export function OrganizationDetail() {
     }
   }
 
-  const formatDate = (timestamp: { seconds: bigint; nanos: number } | undefined) => {
+  const formatDate = (timestamp: Timestamp | undefined) => {
     if (!timestamp) return "—"
     return timestampDate(timestamp).toLocaleString()
   }

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -1,0 +1,170 @@
+import { useState } from "react"
+import { useNavigate, useLocation, Link } from "react-router-dom"
+import { Radio } from "lucide-react"
+import { useAuth } from "@/lib/auth"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Field,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
+
+function SignupForm({ className, ...props }: React.ComponentProps<"div">) {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { register } = useAuth()
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const from = (location.state as { from?: string })?.from || "/organizations"
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setError(null)
+    setIsLoading(true)
+
+    const formData = new FormData(e.currentTarget)
+    const name = formData.get("name") as string
+    const email = formData.get("email") as string
+    const password = formData.get("password") as string
+    const confirmPassword = formData.get("confirm-password") as string
+
+    if (password !== confirmPassword) {
+      setError("Passwords do not match")
+      setIsLoading(false)
+      return
+    }
+
+    if (password.length < 8) {
+      setError("Password must be at least 8 characters")
+      setIsLoading(false)
+      return
+    }
+
+    try {
+      await register(email, password, name)
+      navigate(from, { replace: true })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Registration failed"
+      // Format gRPC error codes into user-friendly messages
+      if (message.includes("[already_exists]")) {
+        setError("An account with this email already exists. Try signing in instead.")
+      } else {
+        setError(message)
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-6", className)} {...props}>
+      <Card>
+        <CardHeader className="text-center">
+          <CardTitle className="text-xl">Create your account</CardTitle>
+          <CardDescription>
+            Enter your details below to create your account
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit}>
+            <FieldGroup>
+              {error && (
+                <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                  {error}
+                </div>
+              )}
+              <Field>
+                <FieldLabel htmlFor="name">Full Name</FieldLabel>
+                <Input
+                  id="name"
+                  name="name"
+                  type="text"
+                  placeholder="John Doe"
+                  required
+                  disabled={isLoading}
+                />
+              </Field>
+              <Field>
+                <FieldLabel htmlFor="email">Email</FieldLabel>
+                <Input
+                  id="email"
+                  name="email"
+                  type="email"
+                  placeholder="m@example.com"
+                  required
+                  disabled={isLoading}
+                />
+              </Field>
+              <Field>
+                <Field className="grid grid-cols-2 gap-4">
+                  <Field>
+                    <FieldLabel htmlFor="password">Password</FieldLabel>
+                    <Input
+                      id="password"
+                      name="password"
+                      type="password"
+                      required
+                      disabled={isLoading}
+                    />
+                  </Field>
+                  <Field>
+                    <FieldLabel htmlFor="confirm-password">Confirm Password</FieldLabel>
+                    <Input
+                      id="confirm-password"
+                      name="confirm-password"
+                      type="password"
+                      required
+                      disabled={isLoading}
+                    />
+                  </Field>
+                </Field>
+                <FieldDescription>
+                  Must be at least 8 characters long.
+                </FieldDescription>
+              </Field>
+              <Field>
+                <Button type="submit" disabled={isLoading}>
+                  {isLoading ? "Creating account..." : "Create Account"}
+                </Button>
+                <FieldDescription className="text-center">
+                  Already have an account?{" "}
+                  <Link to="/login" state={{ from }}>
+                    Sign in
+                  </Link>
+                </FieldDescription>
+              </Field>
+            </FieldGroup>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export function SignupPage() {
+  return (
+    <div className="bg-muted flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
+      <div className="flex w-full max-w-sm flex-col gap-6">
+        <a href="/" className="flex items-center gap-2 self-center font-medium">
+          <div className="bg-primary text-primary-foreground flex size-6 items-center justify-center rounded-md">
+            <Radio className="size-4" />
+          </div>
+          Ponix
+        </a>
+        <SignupForm />
+      </div>
+    </div>
+  )
+}

--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "ponix-ui",
       "dependencies": {
-        "@buf/ponix_ponix.bufbuild_es": "2.10.1-20251130212524-fb4fe527b8d9.1",
+        "@buf/ponix_ponix.bufbuild_es": "2.10.1-20251206223125-54a23019280d.1",
       },
       "devDependencies": {
         "typescript": "^5.7.2",
@@ -98,7 +98,7 @@
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
-    "@buf/ponix_ponix.bufbuild_es": ["@buf/ponix_ponix.bufbuild_es@2.10.1-20251130212524-fb4fe527b8d9.1", "https://buf.build/gen/npm/v1/@buf/ponix_ponix.bufbuild_es/-/ponix_ponix.bufbuild_es-2.10.1-20251130212524-fb4fe527b8d9.1.tgz", { "peerDependencies": { "@bufbuild/protobuf": "^2.10.1" } }, ""],
+    "@buf/ponix_ponix.bufbuild_es": ["@buf/ponix_ponix.bufbuild_es@2.10.1-20251206223125-54a23019280d.1", "https://buf.build/gen/npm/v1/@buf/ponix_ponix.bufbuild_es/-/ponix_ponix.bufbuild_es-2.10.1-20251206223125-54a23019280d.1.tgz", { "peerDependencies": { "@bufbuild/protobuf": "^2.10.1" } }, ""],
 
     "@bufbuild/protobuf": ["@bufbuild/protobuf@2.10.1", "", {}, "sha512-ckS3+vyJb5qGpEYv/s1OebUHDi/xSNtfgw1wqKZo7MR9F2z+qXr0q5XagafAG/9O0QPVIUfST0smluYSTpYFkg=="],
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@buf/ponix_ponix.bufbuild_es": "2.10.1-20251130212524-fb4fe527b8d9.1"
+    "@buf/ponix_ponix.bufbuild_es": "2.10.1-20251206223125-54a23019280d.1"
   }
 }


### PR DESCRIPTION
## Summary

Implements complete authentication UI flow for Ponix, including login/registration pages, protected routes, and user menu integration.

- **Login Page** - Clean shadcn-styled login form with email/password fields, friendly error messages for invalid credentials
- **Signup Page** - Registration form with password confirmation, friendly error messages for duplicate emails
- **Auth Context** - React context managing user state, JWT access tokens (in memory), and automatic token refresh
- **Protected Routes** - `RequireAuth` wrapper component redirects unauthenticated users to login, preserving original destination
- **User Menu** - Avatar dropdown in sidebar footer with logout functionality
- **API Transport** - Bearer token automatically attached to all authenticated requests via token getter pattern

### Key Implementation Details

**Security**
- Access token stored in memory only (not localStorage)
- Refresh token handled via HTTP-only cookie with `credentials: "include"`
- Token getter pattern keeps token internal to AuthContext while allowing transport access

**User Experience**
- Loading state shown during initial auth check
- Redirect to original destination after login
- Friendly error messages for common auth errors (`[unauthenticated]`, `[already_exists]`)

### Files Changed

| Area | Files |
|------|-------|
| Auth Context | `lib/auth/AuthContext.tsx`, `lib/auth/types.ts`, `lib/auth/index.ts` |
| Pages | `pages/LoginPage.tsx`, `pages/SignupPage.tsx` |
| Components | `components/auth/RequireAuth.tsx`, `components/layout/UserMenu.tsx` |
| API Layer | `lib/api/transport.ts`, `lib/api/client.ts`, `lib/api/index.ts` |
| App Config | `App.tsx` (routes + AuthProvider) |
| Layout | `components/layout/AppSidebar.tsx` (UserMenu integration) |
| UI | `components/ui/field.tsx` (shadcn field component) |

## Test plan

- [ ] Navigate to protected route while logged out → redirected to `/login`
- [ ] Login with valid credentials → redirected to original destination
- [ ] Login with invalid credentials → friendly error message shown
- [ ] Register new account → auto-login and redirect
- [ ] Register with existing email → friendly "already exists" error
- [ ] Click logout in user menu → redirected to login
- [ ] Refresh page while logged in → session persists (requires backend cookie fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)