### PR TITLE
feat: expand E2E test coverage for all user flows

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -26,3 +26,11 @@ run = "bun run build"
 [tasks.typecheck]
 description = "Type check all packages"
 run = "bun run typecheck"
+
+[tasks.e2e]
+description = "Run Playwright E2E tests"
+run = "bunx playwright test"
+
+[tasks."e2e:ui"]
+description = "Run Playwright E2E tests with UI"
+run = "bunx playwright test --ui"

--- a/e2e/mocks/handlers.ts
+++ b/e2e/mocks/handlers.ts
@@ -26,28 +26,129 @@ export const TEST_ORG = {
   name: "Test Org",
 }
 
+export const TEST_GATEWAY = {
+  gatewayId: "gw-1",
+  organizationId: TEST_ORG.id,
+  name: "Test Gateway",
+  status: 1,
+  type: 1,
+  emqxConfig: { brokerUrl: "mqtt://broker:1883" },
+}
+
+export const TEST_WORKSPACE = {
+  id: "ws-1",
+  organizationId: TEST_ORG.id,
+  name: "Test Workspace",
+  status: 1,
+}
+
+export const TEST_DEFINITION = {
+  id: "def-1",
+  organizationId: TEST_ORG.id,
+  name: "Test Definition",
+  contracts: [
+    {
+      matchExpression: "true",
+      transformExpression: "payload",
+      jsonSchema: "{}",
+    },
+  ],
+}
+
+export const TEST_DATA_STREAM = {
+  dataStreamId: "ds-1",
+  organizationId: TEST_ORG.id,
+  name: "Test Stream",
+  definitionId: TEST_DEFINITION.id,
+  workspaceId: TEST_WORKSPACE.id,
+  gatewayId: TEST_GATEWAY.gatewayId,
+}
+
 // ── Response factories ──
 
 export const responses = {
+  // Auth
   login: () => ({ token: TEST_TOKEN }),
   refresh: () => ({ accessToken: TEST_TOKEN }),
   getUser: () => ({ user: TEST_USER }),
   logout: () => ({}),
+  register: () => ({ user: TEST_USER }),
+
+  // Organizations
   userOrganizations: (orgs = [TEST_ORG]) => ({ organizations: orgs }),
   createOrganization: (id = "org-new", name = "New Org") => ({
     organizationId: id,
   }),
+  getOrganization: (org = TEST_ORG) => ({ organization: org }),
+
+  // Gateways
+  listGateways: (gateways = [TEST_GATEWAY]) => ({ gateways }),
+  createGateway: (gateway = TEST_GATEWAY) => ({ gateway }),
+  getGateway: (gateway = TEST_GATEWAY) => ({ gateway }),
+
+  // Workspaces
+  listWorkspaces: (workspaces = [TEST_WORKSPACE]) => ({ workspaces }),
+  createWorkspace: (workspace = TEST_WORKSPACE) => ({ workspace }),
+  getWorkspace: (workspace = TEST_WORKSPACE) => ({ workspace }),
+
+  // Definitions
+  listDefinitions: (definitions = [TEST_DEFINITION]) => ({
+    dataStreamDefinitions: definitions,
+  }),
+  createDefinition: (definition = TEST_DEFINITION) => ({
+    dataStreamDefinition: definition,
+  }),
+  getDefinition: (definition = TEST_DEFINITION) => ({
+    dataStreamDefinition: definition,
+  }),
+
+  // Data Streams
+  listWorkspaceDataStreams: (dataStreams = [TEST_DATA_STREAM]) => ({
+    dataStreams,
+  }),
+  listGatewayDataStreams: (dataStreams = [TEST_DATA_STREAM]) => ({
+    dataStreams,
+  }),
+  createDataStream: (dataStream = TEST_DATA_STREAM) => ({ dataStream }),
 }
 
 // ── Service paths ──
 
 export const services = {
+  // Auth
   login: "user.v1.UserService/Login",
   refresh: "user.v1.UserService/Refresh",
   getUser: "user.v1.UserService/GetUser",
   logout: "user.v1.UserService/Logout",
+  register: "user.v1.UserService/RegisterUser",
+
+  // Organizations
   userOrganizations: "organization.v1.OrganizationService/UserOrganizations",
   createOrganization: "organization.v1.OrganizationService/CreateOrganization",
+  getOrganization: "organization.v1.OrganizationService/GetOrganization",
+
+  // Gateways
+  listGateways: "gateway.v1.GatewayService/ListGateways",
+  createGateway: "gateway.v1.GatewayService/CreateGateway",
+  getGateway: "gateway.v1.GatewayService/GetGateway",
+
+  // Workspaces
+  listWorkspaces: "workspace.v1.WorkspaceService/ListWorkspaces",
+  createWorkspace: "workspace.v1.WorkspaceService/CreateWorkspace",
+  getWorkspace: "workspace.v1.WorkspaceService/GetWorkspace",
+
+  // Definitions
+  listDefinitions:
+    "data_stream.v1.DataStreamDefinitionService/ListDataStreamDefinitions",
+  createDefinition:
+    "data_stream.v1.DataStreamDefinitionService/CreateDataStreamDefinition",
+  getDefinition:
+    "data_stream.v1.DataStreamDefinitionService/GetDataStreamDefinition",
+
+  // Data Streams
+  getWorkspaceDataStreams: "data_stream.v1.DataStreamService/GetWorkspaceDataStreams",
+  getGatewayDataStreams: "data_stream.v1.DataStreamService/GetGatewayDataStreams",
+  createDataStream: "data_stream.v1.DataStreamService/CreateDataStream",
 } as const
 
 // ── ConnectRPC error helpers ──

--- a/e2e/tests/data-streams.spec.ts
+++ b/e2e/tests/data-streams.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from "../fixtures/auth"
+import { mockGrpc } from "../fixtures/grpc"
+import {
+  services,
+  responses,
+  TEST_ORG,
+  TEST_WORKSPACE,
+  TEST_GATEWAY,
+  TEST_DEFINITION,
+} from "../mocks/handlers"
+
+test.describe("data streams", () => {
+  test.beforeEach(async ({ authenticatedPage: page }) => {
+    await mockGrpc(
+      page,
+      services.getOrganization,
+      responses.getOrganization(),
+    )
+    await mockGrpc(page, services.getWorkspace, responses.getWorkspace())
+  })
+
+  test("empty state shows message", async ({ authenticatedPage: page }) => {
+    await mockGrpc(
+      page,
+      services.getWorkspaceDataStreams,
+      responses.listWorkspaceDataStreams([]),
+    )
+    // Loader also fetches definitions and gateways for the create form
+    await mockGrpc(
+      page,
+      services.listDefinitions,
+      responses.listDefinitions(),
+    )
+    await mockGrpc(page, services.listGateways, responses.listGateways())
+
+    await page.goto(
+      `/organizations/${TEST_ORG.id}/workspaces/${TEST_WORKSPACE.id}/data-streams`,
+    )
+
+    await expect(page.getByText("No data streams registered")).toBeVisible()
+  })
+
+  test("create data stream wizard", async ({ authenticatedPage: page }) => {
+    await mockGrpc(
+      page,
+      services.getWorkspaceDataStreams,
+      responses.listWorkspaceDataStreams([]),
+    )
+    await mockGrpc(
+      page,
+      services.listDefinitions,
+      responses.listDefinitions(),
+    )
+    await mockGrpc(page, services.listGateways, responses.listGateways())
+    await mockGrpc(
+      page,
+      services.createDataStream,
+      responses.createDataStream(),
+    )
+
+    await page.goto(
+      `/organizations/${TEST_ORG.id}/workspaces/${TEST_WORKSPACE.id}/data-streams`,
+    )
+
+    await page.getByRole("button", { name: "Add Data Stream" }).click()
+
+    // Step 1: Name
+    await expect(
+      page.getByRole("heading", { name: "Create Data Stream" }),
+    ).toBeVisible()
+    await page.getByLabel("Name").fill("My Data Stream")
+    await page.getByRole("button", { name: "Next" }).click()
+
+    // Step 2: Select definition — the combobox trigger
+    await expect(page.getByText("Step 2 of 3")).toBeVisible()
+    await page.getByRole("combobox").click()
+    await page.getByRole("option", { name: TEST_DEFINITION.name }).click()
+    await page.getByRole("button", { name: "Next" }).click()
+
+    // Step 3: Select gateway
+    await expect(page.getByText("Step 3 of 3")).toBeVisible()
+    await page.getByRole("combobox").click()
+    await page.getByRole("option", { name: TEST_GATEWAY.name }).click()
+
+    // After creating, re-mock the list
+    await mockGrpc(
+      page,
+      services.getWorkspaceDataStreams,
+      responses.listWorkspaceDataStreams(),
+    )
+
+    await page.getByRole("button", { name: "Create Data Stream" }).click()
+
+    // Dialog should close
+    await expect(
+      page.getByRole("button", { name: "Add Data Stream" }),
+    ).toBeVisible()
+  })
+})

--- a/e2e/tests/definitions.spec.ts
+++ b/e2e/tests/definitions.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "../fixtures/auth"
+import { mockGrpc } from "../fixtures/grpc"
+import {
+  services,
+  responses,
+  TEST_ORG,
+  TEST_DEFINITION,
+} from "../mocks/handlers"
+
+test.describe("definitions", () => {
+  test.beforeEach(async ({ authenticatedPage: page }) => {
+    await mockGrpc(
+      page,
+      services.getOrganization,
+      responses.getOrganization(),
+    )
+  })
+
+  test("empty state shows message", async ({ authenticatedPage: page }) => {
+    await mockGrpc(
+      page,
+      services.listDefinitions,
+      responses.listDefinitions([]),
+    )
+
+    await page.goto(`/organizations/${TEST_ORG.id}/definitions`)
+
+    await expect(page.getByText("No definitions configured")).toBeVisible()
+  })
+
+  test("lists definitions with contract badge", async ({
+    authenticatedPage: page,
+  }) => {
+    await mockGrpc(
+      page,
+      services.listDefinitions,
+      responses.listDefinitions(),
+    )
+
+    await page.goto(`/organizations/${TEST_ORG.id}/definitions`)
+
+    await expect(page.getByText(TEST_DEFINITION.name)).toBeVisible()
+    await expect(page.getByText("1 contract")).toBeVisible()
+  })
+
+  test("create definition wizard", async ({ authenticatedPage: page }) => {
+    await mockGrpc(
+      page,
+      services.listDefinitions,
+      responses.listDefinitions([]),
+    )
+    await mockGrpc(
+      page,
+      services.createDefinition,
+      responses.createDefinition(),
+    )
+
+    await page.goto(`/organizations/${TEST_ORG.id}/definitions`)
+
+    await page.getByRole("button", { name: "Add Definition" }).click()
+
+    // Step 1: General
+    await expect(
+      page.getByText("Create Data Stream Definition"),
+    ).toBeVisible()
+    await page.getByLabel("Name").fill("Temperature Sensor v1")
+
+    await page.getByRole("button", { name: "Next" }).click()
+
+    // Step 2: Contracts
+    await expect(page.getByText("Payload Contracts")).toBeVisible()
+
+    // After creating, re-mock the list
+    await mockGrpc(
+      page,
+      services.listDefinitions,
+      responses.listDefinitions(),
+    )
+
+    await page.getByRole("button", { name: "Create Definition" }).click()
+
+    // Dialog should close
+    await expect(
+      page.getByRole("button", { name: "Add Definition" }),
+    ).toBeVisible()
+  })
+})

--- a/e2e/tests/gateways.spec.ts
+++ b/e2e/tests/gateways.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from "../fixtures/auth"
+import { mockGrpc } from "../fixtures/grpc"
+import {
+  services,
+  responses,
+  TEST_ORG,
+  TEST_GATEWAY,
+} from "../mocks/handlers"
+
+test.describe("gateways", () => {
+  test.beforeEach(async ({ authenticatedPage: page }) => {
+    await mockGrpc(
+      page,
+      services.getOrganization,
+      responses.getOrganization(),
+    )
+  })
+
+  test("empty state shows message", async ({ authenticatedPage: page }) => {
+    await mockGrpc(page, services.listGateways, responses.listGateways([]))
+
+    await page.goto(`/organizations/${TEST_ORG.id}/gateways`)
+
+    await expect(page.getByText("No gateways configured")).toBeVisible()
+  })
+
+  test("lists gateways", async ({ authenticatedPage: page }) => {
+    await mockGrpc(page, services.listGateways, responses.listGateways())
+
+    await page.goto(`/organizations/${TEST_ORG.id}/gateways`)
+
+    await expect(page.getByText(TEST_GATEWAY.name)).toBeVisible()
+    await expect(page.getByText(TEST_GATEWAY.gatewayId)).toBeVisible()
+    await expect(page.getByText("EMQX")).toBeVisible()
+  })
+
+  test("create gateway wizard", async ({ authenticatedPage: page }) => {
+    await mockGrpc(page, services.listGateways, responses.listGateways([]))
+    await mockGrpc(page, services.createGateway, responses.createGateway())
+
+    await page.goto(`/organizations/${TEST_ORG.id}/gateways`)
+
+    // Open create dialog
+    await page.getByRole("button", { name: "Add Gateway" }).click()
+
+    // Step 1: General
+    await expect(page.getByText("Step 1 of 2")).toBeVisible()
+    await page.getByLabel("Name").fill("My New Gateway")
+
+    // Select gateway type via the Select trigger (combobox role)
+    await page.getByRole("combobox").click()
+    await page.getByRole("option", { name: "EMQX" }).click()
+
+    await page.getByRole("button", { name: "Next" }).click()
+
+    // Step 2: Configuration
+    await expect(page.getByText("Step 2 of 2")).toBeVisible()
+    await page
+      .getByLabel("Broker URL")
+      .fill("mqtt://broker.example.com:1883")
+
+    // After creating, re-mock the list to include the new gateway
+    await mockGrpc(page, services.listGateways, responses.listGateways())
+
+    await page.getByRole("button", { name: "Create Gateway" }).click()
+
+    // Dialog should close and gateway should appear in list
+    await expect(page.getByText(TEST_GATEWAY.name)).toBeVisible()
+  })
+
+  test("gateway overview shows details", async ({
+    authenticatedPage: page,
+  }) => {
+    await mockGrpc(page, services.getGateway, responses.getGateway())
+
+    await page.goto(
+      `/organizations/${TEST_ORG.id}/gateways/${TEST_GATEWAY.gatewayId}/overview`,
+    )
+
+    // Header shows gateway name
+    await expect(
+      page.getByRole("heading", { name: TEST_GATEWAY.name }),
+    ).toBeVisible()
+    // Info cards
+    await expect(page.getByText(TEST_GATEWAY.gatewayId)).toBeVisible()
+    await expect(page.getByText("EMQX")).toBeVisible()
+    // Configuration section
+    await expect(
+      page.getByText(TEST_GATEWAY.emqxConfig.brokerUrl),
+    ).toBeVisible()
+  })
+})

--- a/e2e/tests/logout.spec.ts
+++ b/e2e/tests/logout.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "../fixtures/auth"
+import { mockGrpc } from "../fixtures/grpc"
+import { services, connectError } from "../mocks/handlers"
+
+test.describe("logout", () => {
+  test("logout redirects to login", async ({ authenticatedPage: page }) => {
+    await page.goto("/organizations")
+    await expect(page.getByText("Your Organizations")).toBeVisible()
+
+    // Click the avatar/user menu button (shows user initials "TU")
+    await page.getByRole("button", { name: "TU" }).click()
+
+    // Mock logout to clear auth, then refresh should fail
+    await mockGrpc(
+      page,
+      services.refresh,
+      connectError("unauthenticated", "Not authenticated"),
+      401,
+    )
+
+    await page.getByText("Log out").click()
+
+    await expect(page).toHaveURL(/\/login/, { timeout: 10000 })
+  })
+})

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect } from "../fixtures/auth"
+import { mockGrpc } from "../fixtures/grpc"
+import {
+  services,
+  responses,
+  TEST_ORG,
+  TEST_GATEWAY,
+  TEST_WORKSPACE,
+  TEST_DEFINITION,
+} from "../mocks/handlers"
+
+test.describe("navigation", () => {
+  test.beforeEach(async ({ authenticatedPage: page }) => {
+    await mockGrpc(
+      page,
+      services.getOrganization,
+      responses.getOrganization(),
+    )
+  })
+
+  test("org switcher shows organizations", async ({
+    authenticatedPage: page,
+  }) => {
+    await mockGrpc(
+      page,
+      services.listWorkspaces,
+      responses.listWorkspaces([]),
+    )
+
+    await page.goto(`/organizations/${TEST_ORG.id}/workspaces`)
+
+    // Click org switcher button (shows org name)
+    await page.getByRole("button", { name: TEST_ORG.name }).click()
+
+    // Should show org list in dropdown
+    await expect(
+      page.getByRole("menuitem", { name: TEST_ORG.name }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole("menuitem", { name: "All Organizations" }),
+    ).toBeVisible()
+  })
+
+  test("sidebar shows org-level nav items", async ({
+    authenticatedPage: page,
+  }) => {
+    await mockGrpc(
+      page,
+      services.listWorkspaces,
+      responses.listWorkspaces([]),
+    )
+
+    await page.goto(`/organizations/${TEST_ORG.id}/workspaces`)
+
+    // Check sidebar nav links exist
+    await expect(
+      page.getByRole("link", { name: "Workspaces" }),
+    ).toBeVisible()
+    await expect(page.getByRole("link", { name: "Gateways" })).toBeVisible()
+    await expect(
+      page.getByRole("link", { name: "Definitions" }),
+    ).toBeVisible()
+  })
+
+  test("sidebar changes for gateway detail", async ({
+    authenticatedPage: page,
+  }) => {
+    await mockGrpc(page, services.getGateway, responses.getGateway())
+
+    await page.goto(
+      `/organizations/${TEST_ORG.id}/gateways/${TEST_GATEWAY.gatewayId}/overview`,
+    )
+
+    // Back breadcrumb link to gateways list
+    const backLink = page.getByRole("link", { name: "Gateways" })
+    await expect(backLink).toBeVisible()
+
+    // Gateway name in sidebar header
+    await expect(page.getByText(TEST_GATEWAY.name).first()).toBeVisible()
+
+    // Nav items: Overview and Data Streams links
+    await expect(
+      page.getByRole("link", { name: "Overview" }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole("link", { name: "Data Streams" }),
+    ).toBeVisible()
+  })
+
+  test("sidebar changes for workspace detail", async ({
+    authenticatedPage: page,
+  }) => {
+    await mockGrpc(page, services.getWorkspace, responses.getWorkspace())
+    await mockGrpc(
+      page,
+      services.getWorkspaceDataStreams,
+      responses.listWorkspaceDataStreams([]),
+    )
+    await mockGrpc(
+      page,
+      services.listDefinitions,
+      responses.listDefinitions(),
+    )
+    await mockGrpc(page, services.listGateways, responses.listGateways())
+
+    await page.goto(
+      `/organizations/${TEST_ORG.id}/workspaces/${TEST_WORKSPACE.id}/data-streams`,
+    )
+
+    // Back breadcrumb link
+    const backLink = page.getByRole("link", { name: "Workspaces" })
+    await expect(backLink).toBeVisible()
+
+    // Workspace name in sidebar
+    await expect(page.getByText(TEST_WORKSPACE.name).first()).toBeVisible()
+
+    // Data Streams nav link
+    await expect(
+      page.getByRole("link", { name: "Data Streams" }),
+    ).toBeVisible()
+  })
+
+  test("sidebar changes for definition detail", async ({
+    authenticatedPage: page,
+  }) => {
+    await mockGrpc(
+      page,
+      services.getDefinition,
+      responses.getDefinition(),
+    )
+
+    await page.goto(
+      `/organizations/${TEST_ORG.id}/definitions/${TEST_DEFINITION.id}/overview`,
+    )
+
+    // Back breadcrumb link
+    const backLink = page.getByRole("link", { name: "Definitions" })
+    await expect(backLink).toBeVisible()
+
+    // Definition name in sidebar
+    await expect(
+      page.getByText(TEST_DEFINITION.name).first(),
+    ).toBeVisible()
+
+    // Overview nav link
+    await expect(
+      page.getByRole("link", { name: "Overview" }),
+    ).toBeVisible()
+  })
+})

--- a/e2e/tests/signup.spec.ts
+++ b/e2e/tests/signup.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from "@playwright/test"
+import { mockGrpc } from "../fixtures/grpc"
+import {
+  services,
+  responses,
+  connectError,
+} from "../mocks/handlers"
+
+test.describe("signup", () => {
+  test.beforeEach(async ({ page }) => {
+    // Ensure unauthenticated state
+    await mockGrpc(
+      page,
+      services.refresh,
+      connectError("unauthenticated", "Not authenticated"),
+      401,
+    )
+  })
+
+  test("renders signup form", async ({ page }) => {
+    await page.goto("/signup")
+
+    await expect(
+      page.getByText("Create your account", { exact: true }),
+    ).toBeVisible()
+    await expect(page.getByLabel("Full Name")).toBeVisible()
+    await expect(page.getByLabel("Email")).toBeVisible()
+    await expect(page.getByLabel("Password", { exact: true })).toBeVisible()
+    await expect(page.getByLabel("Confirm Password")).toBeVisible()
+    await expect(
+      page.getByRole("button", { name: "Create Account" }),
+    ).toBeVisible()
+  })
+
+  test("validation: passwords do not match", async ({ page }) => {
+    await page.goto("/signup")
+
+    await page.getByLabel("Full Name").fill("Test User")
+    await page.getByLabel("Email").fill("test@example.com")
+    await page.getByLabel("Password", { exact: true }).fill("password123")
+    await page.getByLabel("Confirm Password").fill("different123")
+    await page.getByRole("button", { name: "Create Account" }).click()
+
+    await expect(page.getByText("Passwords do not match")).toBeVisible()
+  })
+
+  test("validation: password too short", async ({ page }) => {
+    await page.goto("/signup")
+
+    await page.getByLabel("Full Name").fill("Test User")
+    await page.getByLabel("Email").fill("test@example.com")
+    await page.getByLabel("Password", { exact: true }).fill("short")
+    await page.getByLabel("Confirm Password").fill("short")
+    await page.getByRole("button", { name: "Create Account" }).click()
+
+    await expect(
+      page.getByText("Password must be at least 8 characters"),
+    ).toBeVisible()
+  })
+
+  test("duplicate email shows error", async ({ page }) => {
+    await mockGrpc(
+      page,
+      services.register,
+      connectError("already_exists", "User already exists"),
+      409,
+    )
+
+    await page.goto("/signup")
+
+    await page.getByLabel("Full Name").fill("Test User")
+    await page.getByLabel("Email").fill("existing@example.com")
+    await page.getByLabel("Password", { exact: true }).fill("password123")
+    await page.getByLabel("Confirm Password").fill("password123")
+    await page.getByRole("button", { name: "Create Account" }).click()
+
+    await expect(
+      page.getByText("An account with this email already exists"),
+    ).toBeVisible()
+  })
+
+  test("successful signup redirects to organizations", async ({ page }) => {
+    await mockGrpc(page, services.register, responses.register())
+    await mockGrpc(page, services.login, responses.login())
+    // After login, auth refresh + getUser will be called
+    await mockGrpc(page, services.refresh, responses.refresh())
+    await mockGrpc(page, services.getUser, responses.getUser())
+    await mockGrpc(
+      page,
+      services.userOrganizations,
+      responses.userOrganizations(),
+    )
+
+    await page.goto("/signup")
+
+    await page.getByLabel("Full Name").fill("Test User")
+    await page.getByLabel("Email").fill("new@example.com")
+    await page.getByLabel("Password", { exact: true }).fill("password123")
+    await page.getByLabel("Confirm Password").fill("password123")
+    await page.getByRole("button", { name: "Create Account" }).click()
+
+    await expect(page).toHaveURL(/\/organizations/, { timeout: 10000 })
+  })
+})

--- a/e2e/tests/workspaces.spec.ts
+++ b/e2e/tests/workspaces.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from "../fixtures/auth"
+import { mockGrpc } from "../fixtures/grpc"
+import {
+  services,
+  responses,
+  TEST_ORG,
+  TEST_WORKSPACE,
+} from "../mocks/handlers"
+
+test.describe("workspaces", () => {
+  test.beforeEach(async ({ authenticatedPage: page }) => {
+    await mockGrpc(
+      page,
+      services.getOrganization,
+      responses.getOrganization(),
+    )
+  })
+
+  test("empty state shows message", async ({ authenticatedPage: page }) => {
+    await mockGrpc(
+      page,
+      services.listWorkspaces,
+      responses.listWorkspaces([]),
+    )
+
+    await page.goto(`/organizations/${TEST_ORG.id}/workspaces`)
+
+    await expect(page.getByText("No workspaces created yet")).toBeVisible()
+  })
+
+  test("lists workspaces", async ({ authenticatedPage: page }) => {
+    await mockGrpc(page, services.listWorkspaces, responses.listWorkspaces())
+
+    await page.goto(`/organizations/${TEST_ORG.id}/workspaces`)
+
+    await expect(page.getByText(TEST_WORKSPACE.name)).toBeVisible()
+    await expect(page.getByText(TEST_WORKSPACE.id)).toBeVisible()
+  })
+
+  test("create workspace", async ({ authenticatedPage: page }) => {
+    await mockGrpc(
+      page,
+      services.listWorkspaces,
+      responses.listWorkspaces([]),
+    )
+    await mockGrpc(
+      page,
+      services.createWorkspace,
+      responses.createWorkspace(),
+    )
+
+    await page.goto(`/organizations/${TEST_ORG.id}/workspaces`)
+
+    await page.getByRole("button", { name: "Add Workspace" }).click()
+
+    await expect(
+      page.getByRole("heading", { name: "Create Workspace" }),
+    ).toBeVisible()
+    await page.getByLabel("Name").fill("My Workspace")
+
+    // After creating, re-mock the list to include the new workspace
+    await mockGrpc(
+      page,
+      services.listWorkspaces,
+      responses.listWorkspaces(),
+    )
+
+    await page.getByRole("button", { name: "Create Workspace" }).click()
+
+    // Dialog should close
+    await expect(
+      page.getByRole("button", { name: "Add Workspace" }),
+    ).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

Adds comprehensive E2E test coverage for all remaining user flows, bringing the test suite from 7 to 30 tests. Closes #20.

## Changes

- **`e2e/mocks/handlers.ts`** — Added test constants (`TEST_GATEWAY`, `TEST_WORKSPACE`, `TEST_DEFINITION`, `TEST_DATA_STREAM`), 13 new response factories, and 14 new service paths covering all gRPC endpoints
- **`e2e/tests/signup.spec.ts`** (5 tests) — Form rendering, password validation, duplicate email error, successful signup
- **`e2e/tests/logout.spec.ts`** (1 test) — Logout redirects to login
- **`e2e/tests/gateways.spec.ts`** (4 tests) — Empty state, list, 2-step create wizard, overview detail
- **`e2e/tests/workspaces.spec.ts`** (3 tests) — Empty state, list, create dialog
- **`e2e/tests/definitions.spec.ts`** (3 tests) — Empty state, list with contract badge, 2-step create wizard
- **`e2e/tests/data-streams.spec.ts`** (2 tests) — Empty state, 3-step create wizard (name → definition → gateway)
- **`e2e/tests/navigation.spec.ts`** (5 tests) — Org switcher, org-level sidebar, gateway/workspace/definition detail sidebars
- **`.mise.toml`** — Added `e2e` and `e2e:ui` mise tasks

## Test plan

- [x] All 30 E2E tests pass (`bunx playwright test`)
- [x] All 7 existing tests continue passing
- [x] 23 new tests added across 7 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)